### PR TITLE
SCSS: rename files to avoid conflict with jekyll

### DIFF
--- a/css/fvwm3-carousel.scss
+++ b/css/fvwm3-carousel.scss
@@ -6,5 +6,5 @@
 
 // Import partials from `_sass`
 @import
-        "fvwm3-carousel"
+        "_fvwm3-carousel"
 ;

--- a/css/fvwm3.scss
+++ b/css/fvwm3.scss
@@ -5,7 +5,7 @@
 
 // Import partials from `_sass`
 @import
-        "fvwmvars",
-        "fvwm3",
-	"fvwmwindow"
+        "_fvwmvars",
+        "_fvwm3",
+	"_fvwmwindow"
 ;

--- a/css/monokai.scss
+++ b/css/monokai.scss
@@ -5,6 +5,6 @@
 
 // Import partials from `_sass`
 @import
-        "fvwmvars",
-	"monokai"
+        "_fvwmvars",
+	"_monokai"
 ;


### PR DESCRIPTION
It seems something has changed in jekyll or its dependencies, such that, without this chane `jekyll serve` fails:

jekyll/converters/scss.rb:175:in `rescue in convert': expected "{". (Jekyll::Converters::Scss::SyntaxError)

It is unclear precisely why this change is required, but it looks as though it disambiguates between the same-named files used elsewhere.